### PR TITLE
refactor: 도메인과 API 간의 결합을 줄이기 위해 DTO를 사용

### DIFF
--- a/internal/helper/format_time.go
+++ b/internal/helper/format_time.go
@@ -1,0 +1,10 @@
+package helper
+
+import "time"
+
+func FormatTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}

--- a/internal/infrastructure/repository/member_repository_impl_test.go
+++ b/internal/infrastructure/repository/member_repository_impl_test.go
@@ -178,8 +178,8 @@ func TestMemberRepositoryImpl_Delete_Success(t *testing.T) {
 
 	// Verify
 	deletedMember, err := repo.GetByID(member.ID)
-	assert.Error(t, err)
-	assert.Nil(t, deletedMember)
+	assert.NoError(t, err)
+	assert.True(t, deletedMember.IsWithdrawn)
 }
 
 func TestMemberRepositoryImpl_GetAll_Success(t *testing.T) {
@@ -254,13 +254,19 @@ func TestMemberRepositoryImpl_GetStatsByMonth_Success(t *testing.T) {
 	// 회원 탈퇴
 	_ = repo.Delete(member2.ID)
 
+	// 삭제된 회원의 WithdrawnAt을 테스트 월에 포함되도록 설정
+	member2Fetched, _ := repo.GetByID(member2.ID)
+	withdrawnAt := time.Date(2024, 9, 20, 0, 0, 0, 0, time.UTC)
+	member2Fetched.WithdrawnAt = &withdrawnAt
+	_ = repo.Update(member2Fetched)
+
 	// When
 	joined, deleted, err := repo.GetStatsByMonth("2024-09")
 
 	// Then
 	assert.NoError(t, err)
-	assert.Equal(t, 1, joined)
-	assert.Equal(t, 0, deleted)
+	assert.Equal(t, 2, joined)  // 수정된 기대 값
+	assert.Equal(t, 1, deleted) // 수정된 기대 값
 }
 
 func TestMemberRepositoryImpl_GetStatsByMonth_Failure_InvalidMonth(t *testing.T) {

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -39,8 +39,8 @@ func NewRouter(conf configs.Config, db *gorm.DB) *gin.Engine {
 
 	// 회원 관련 설정
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authInteractor := usecases.NewAuthUseCase("commerce-system", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authInteractor)
 	memberController := controller.NewMemberController(memberInteractor, authInteractor)
 	authController := controller.NewAuthController(authInteractor)
 

--- a/internal/interfaces/controller/auth_controller.go
+++ b/internal/interfaces/controller/auth_controller.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"net/http"
 
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 	"github.com/HongJungWan/commerce-system/internal/usecases"
 	"github.com/gin-gonic/gin"
 )
@@ -16,10 +18,7 @@ func NewAuthController(authUseCase *usecases.AuthUseCase) *AuthController {
 }
 
 func (ctrl *AuthController) Login(c *gin.Context) {
-	var loginRequest struct {
-		Username       string `json:"username"`
-		HashedPassword string `json:"hashed_password"`
-	}
+	var loginRequest request.LoginRequest
 
 	if err := c.ShouldBindJSON(&loginRequest); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
@@ -38,5 +37,9 @@ func (ctrl *AuthController) Login(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"token": token})
+	loginResponse := response.LoginResponse{
+		Token: token,
+	}
+
+	c.JSON(http.StatusOK, loginResponse)
 }

--- a/internal/interfaces/controller/member_controller.go
+++ b/internal/interfaces/controller/member_controller.go
@@ -2,11 +2,8 @@ package controller
 
 import (
 	"net/http"
-	"time"
 
-	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
-	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 	"github.com/HongJungWan/commerce-system/internal/usecases"
 	"github.com/gin-gonic/gin"
 )
@@ -30,39 +27,10 @@ func (mc *MemberController) Register(c *gin.Context) {
 		return
 	}
 
-	member := &domain.Member{
-		MemberNumber: req.MemberNumber,
-		Username:     req.Username,
-		FullName:     req.FullName,
-		Email:        req.Email,
-		CreatedAt:    time.Now(),
-	}
-
-	if err := member.SetPassword(req.Password); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "비밀번호 설정에 실패했습니다."})
-		return
-	}
-
-	if err := mc.memberInteractor.Register(member); err != nil {
+	responseData, err := mc.memberInteractor.Register(&req)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
-	}
-	token, _ := mc.authUseCase.GenerateToken(member)
-
-	responseData := response.RegisterMemberResponse{
-		Message: "회원 가입이 완료되었습니다.",
-		Token:   token,
-		User: response.MemberResponse{
-			ID:           member.ID,
-			MemberNumber: member.MemberNumber,
-			Username:     member.Username,
-			FullName:     member.FullName,
-			Email:        member.Email,
-			CreatedAt:    member.CreatedAt.Format(time.RFC3339),
-			IsAdmin:      member.IsAdmin,
-			IsWithdrawn:  member.IsWithdrawn,
-			WithdrawnAt:  formatTime(member.WithdrawnAt),
-		},
 	}
 
 	c.JSON(http.StatusCreated, responseData)
@@ -70,22 +38,10 @@ func (mc *MemberController) Register(c *gin.Context) {
 
 func (mc *MemberController) GetMyInfo(c *gin.Context) {
 	username := c.GetString("username")
-	member, err := mc.memberInteractor.GetByUserName(username)
+	responseData, err := mc.memberInteractor.GetMyInfo(username)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "사용자 정보를 가져올 수 없습니다."})
 		return
-	}
-
-	responseData := response.MemberResponse{
-		ID:           member.ID,
-		MemberNumber: member.MemberNumber,
-		Username:     member.Username,
-		FullName:     member.FullName,
-		Email:        member.Email,
-		CreatedAt:    member.CreatedAt.Format(time.RFC3339),
-		IsAdmin:      member.IsAdmin,
-		IsWithdrawn:  member.IsWithdrawn,
-		WithdrawnAt:  formatTime(member.WithdrawnAt),
 	}
 
 	c.JSON(http.StatusOK, responseData)
@@ -99,19 +55,7 @@ func (mc *MemberController) UpdateMyInfo(c *gin.Context) {
 		return
 	}
 
-	memberUpdate := &domain.Member{
-		FullName: updateData.FullName,
-		Email:    updateData.Email,
-	}
-
-	if updateData.Password != "" {
-		if err := memberUpdate.SetPassword(updateData.Password); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "비밀번호 설정에 실패했습니다."})
-			return
-		}
-	}
-
-	if err := mc.memberInteractor.UpdateByUserName(username, memberUpdate); err != nil {
+	if err := mc.memberInteractor.UpdateMyInfo(username, &updateData); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "업데이트에 실패했습니다."})
 		return
 	}
@@ -119,8 +63,8 @@ func (mc *MemberController) UpdateMyInfo(c *gin.Context) {
 }
 
 func (mc *MemberController) DeleteMyAccount(c *gin.Context) {
-	userName := c.GetString("username")
-	if err := mc.memberInteractor.DeleteByUserName(userName); err != nil {
+	username := c.GetString("username")
+	if err := mc.memberInteractor.DeleteByUserName(username); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "계정 삭제에 실패했습니다."})
 		return
 	}
@@ -133,28 +77,13 @@ func (mc *MemberController) GetAllMembers(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "접근 권한이 없습니다."})
 		return
 	}
-	members, err := mc.memberInteractor.GetAll()
+	responseData, err := mc.memberInteractor.GetAllMembers()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "회원 목록을 가져올 수 없습니다."})
 		return
 	}
 
-	var memberResponses []response.MemberResponse
-	for _, member := range members {
-		memberResponses = append(memberResponses, response.MemberResponse{
-			ID:           member.ID,
-			MemberNumber: member.MemberNumber,
-			Username:     member.Username,
-			FullName:     member.FullName,
-			Email:        member.Email,
-			CreatedAt:    member.CreatedAt.Format(time.RFC3339),
-			IsAdmin:      member.IsAdmin,
-			IsWithdrawn:  member.IsWithdrawn,
-			WithdrawnAt:  formatTime(member.WithdrawnAt),
-		})
-	}
-
-	c.JSON(http.StatusOK, memberResponses)
+	c.JSON(http.StatusOK, responseData)
 }
 
 func (mc *MemberController) GetMemberStats(c *gin.Context) {
@@ -168,21 +97,10 @@ func (mc *MemberController) GetMemberStats(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "month 파라미터가 필요합니다."})
 		return
 	}
-	joined, deleted, err := mc.memberInteractor.GetStatsByMonth(month)
+	stats, err := mc.memberInteractor.GetMemberStats(month)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "통계 정보를 가져올 수 없습니다."})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"month":           month,
-		"joined_members":  joined,
-		"deleted_members": deleted,
-	})
-}
-
-func formatTime(t *time.Time) string {
-	if t == nil {
-		return ""
-	}
-	return t.Format(time.RFC3339)
+	c.JSON(http.StatusOK, stats)
 }

--- a/internal/interfaces/controller/member_controller.go
+++ b/internal/interfaces/controller/member_controller.go
@@ -2,8 +2,11 @@ package controller
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/HongJungWan/commerce-system/internal/domain"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 	"github.com/HongJungWan/commerce-system/internal/usecases"
 	"github.com/gin-gonic/gin"
 )
@@ -21,41 +24,94 @@ func NewMemberController(mi *usecases.MemberInteractor, au *usecases.AuthUseCase
 }
 
 func (mc *MemberController) Register(c *gin.Context) {
-	var member domain.Member
-	if err := c.ShouldBindJSON(&member); err != nil {
+	var req request.RegisterMemberRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청입니다."})
 		return
 	}
-	if err := mc.memberInteractor.Register(&member); err != nil {
+
+	member := &domain.Member{
+		MemberNumber: req.MemberNumber,
+		Username:     req.Username,
+		FullName:     req.FullName,
+		Email:        req.Email,
+		CreatedAt:    time.Now(),
+	}
+
+	if err := member.SetPassword(req.Password); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "비밀번호 설정에 실패했습니다."})
+		return
+	}
+
+	if err := mc.memberInteractor.Register(member); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	token, _ := mc.authUseCase.GenerateToken(&member)
-	c.JSON(http.StatusCreated, gin.H{
-		"message": "회원 가입이 완료되었습니다.",
-		"token":   token,
-		"user":    member,
-	})
+	token, _ := mc.authUseCase.GenerateToken(member)
+
+	responseData := response.RegisterMemberResponse{
+		Message: "회원 가입이 완료되었습니다.",
+		Token:   token,
+		User: response.MemberResponse{
+			ID:           member.ID,
+			MemberNumber: member.MemberNumber,
+			Username:     member.Username,
+			FullName:     member.FullName,
+			Email:        member.Email,
+			CreatedAt:    member.CreatedAt.Format(time.RFC3339),
+			IsAdmin:      member.IsAdmin,
+			IsWithdrawn:  member.IsWithdrawn,
+			WithdrawnAt:  formatTime(member.WithdrawnAt),
+		},
+	}
+
+	c.JSON(http.StatusCreated, responseData)
 }
 
 func (mc *MemberController) GetMyInfo(c *gin.Context) {
-	userID := c.GetString("username")
-	member, err := mc.memberInteractor.GetByUserName(userID)
+	username := c.GetString("username")
+	member, err := mc.memberInteractor.GetByUserName(username)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "사용자 정보를 가져올 수 없습니다."})
 		return
 	}
-	c.JSON(http.StatusOK, member)
+
+	responseData := response.MemberResponse{
+		ID:           member.ID,
+		MemberNumber: member.MemberNumber,
+		Username:     member.Username,
+		FullName:     member.FullName,
+		Email:        member.Email,
+		CreatedAt:    member.CreatedAt.Format(time.RFC3339),
+		IsAdmin:      member.IsAdmin,
+		IsWithdrawn:  member.IsWithdrawn,
+		WithdrawnAt:  formatTime(member.WithdrawnAt),
+	}
+
+	c.JSON(http.StatusOK, responseData)
 }
 
 func (mc *MemberController) UpdateMyInfo(c *gin.Context) {
-	userID := c.GetString("username")
-	var updateData domain.Member
+	username := c.GetString("username")
+	var updateData request.UpdateMemberRequest
 	if err := c.ShouldBindJSON(&updateData); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청입니다."})
 		return
 	}
-	if err := mc.memberInteractor.UpdateByUserID(userID, &updateData); err != nil {
+
+	memberUpdate := &domain.Member{
+		FullName: updateData.FullName,
+		Email:    updateData.Email,
+	}
+
+	if updateData.Password != "" {
+		if err := memberUpdate.SetPassword(updateData.Password); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "비밀번호 설정에 실패했습니다."})
+			return
+		}
+	}
+
+	if err := mc.memberInteractor.UpdateByUserName(username, memberUpdate); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "업데이트에 실패했습니다."})
 		return
 	}
@@ -63,8 +119,8 @@ func (mc *MemberController) UpdateMyInfo(c *gin.Context) {
 }
 
 func (mc *MemberController) DeleteMyAccount(c *gin.Context) {
-	userID := c.GetString("username")
-	if err := mc.memberInteractor.DeleteByUserID(userID); err != nil {
+	userName := c.GetString("username")
+	if err := mc.memberInteractor.DeleteByUserName(userName); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "계정 삭제에 실패했습니다."})
 		return
 	}
@@ -82,7 +138,23 @@ func (mc *MemberController) GetAllMembers(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "회원 목록을 가져올 수 없습니다."})
 		return
 	}
-	c.JSON(http.StatusOK, members)
+
+	var memberResponses []response.MemberResponse
+	for _, member := range members {
+		memberResponses = append(memberResponses, response.MemberResponse{
+			ID:           member.ID,
+			MemberNumber: member.MemberNumber,
+			Username:     member.Username,
+			FullName:     member.FullName,
+			Email:        member.Email,
+			CreatedAt:    member.CreatedAt.Format(time.RFC3339),
+			IsAdmin:      member.IsAdmin,
+			IsWithdrawn:  member.IsWithdrawn,
+			WithdrawnAt:  formatTime(member.WithdrawnAt),
+		})
+	}
+
+	c.JSON(http.StatusOK, memberResponses)
 }
 
 func (mc *MemberController) GetMemberStats(c *gin.Context) {
@@ -106,4 +178,11 @@ func (mc *MemberController) GetMemberStats(c *gin.Context) {
 		"joined_members":  joined,
 		"deleted_members": deleted,
 	})
+}
+
+func formatTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
 }

--- a/internal/interfaces/controller/member_controller.go
+++ b/internal/interfaces/controller/member_controller.go
@@ -49,19 +49,18 @@ func (mc *MemberController) GetMyInfo(c *gin.Context) {
 
 func (mc *MemberController) UpdateMyInfo(c *gin.Context) {
 	username := c.GetString("username")
-	var updateData request.UpdateMemberRequest
-	if err := c.ShouldBindJSON(&updateData); err != nil {
+	var req request.UpdateMemberRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 요청입니다."})
 		return
 	}
 
-	if err := mc.memberInteractor.UpdateMyInfo(username, &updateData); err != nil {
+	if err := mc.memberInteractor.UpdateMyInfo(username, &req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "업데이트에 실패했습니다."})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "정보가 수정되었습니다."})
 }
-
 func (mc *MemberController) DeleteMyAccount(c *gin.Context) {
 	username := c.GetString("username")
 	if err := mc.memberInteractor.DeleteByUserName(username); err != nil {

--- a/internal/interfaces/controller/member_controller_test.go
+++ b/internal/interfaces/controller/member_controller_test.go
@@ -264,8 +264,8 @@ func TestMemberController_DeleteMyAccount_Success(t *testing.T) {
 	assert.Equal(t, "계정이 삭제되었습니다.", response["message"])
 
 	deletedMember, err := memberRepo.GetByUserName("testuser")
-	assert.Error(t, err)
-	assert.Nil(t, deletedMember)
+	assert.NoError(t, err)
+	assert.True(t, deletedMember.IsWithdrawn)
 }
 
 func TestMemberController_GetAllMembers_Success(t *testing.T) {

--- a/internal/interfaces/controller/member_controller_test.go
+++ b/internal/interfaces/controller/member_controller_test.go
@@ -197,6 +197,15 @@ func TestMemberController_UpdateMyInfo_Failure_InvalidRequest(t *testing.T) {
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
+	member := &domain.Member{
+		MemberNumber: "M1234",
+		Username:     "testuser",
+		FullName:     "Test User",
+		Email:        "testuser@example.com",
+	}
+	member.SetPassword("password123")
+	memberRepo.Create(member)
+
 	router := gin.Default()
 	router.PUT("/me", func(c *gin.Context) {
 		c.Set("username", "testuser")
@@ -204,7 +213,7 @@ func TestMemberController_UpdateMyInfo_Failure_InvalidRequest(t *testing.T) {
 	})
 
 	invalidRequest := map[string]interface{}{
-		"username": 0, // 잘못된 타입의 값
+		"full_name": 123, // 잘못된 타입
 	}
 	requestBody, _ := json.Marshal(invalidRequest)
 	req, _ := http.NewRequest("PUT", "/me", bytes.NewBuffer(requestBody))

--- a/internal/interfaces/controller/member_controller_test.go
+++ b/internal/interfaces/controller/member_controller_test.go
@@ -3,36 +3,38 @@ package controller_test
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/infrastructure/repository"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/controller"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 	"github.com/HongJungWan/commerce-system/internal/usecases"
 	"github.com/HongJungWan/commerce-system/test/fixtures"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestMemberController_Register_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo) // JWT 시크릿 키 설정
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	router := gin.Default()
 	router.POST("/register", memberController.Register)
 
-	newMember := domain.Member{
-		ID:             1234,
-		MemberNumber:   "P1234",
-		Username:       "newuser",
-		HashedPassword: "password123",
-		FullName:       "New User",
-		Email:          "newuser@example.com",
+	newMember := request.RegisterMemberRequest{
+		MemberNumber: "M1234",
+		Username:     "newuser",
+		Password:     "password123",
+		FullName:     "New User",
+		Email:        "newuser@example.com",
 	}
 
 	requestBody, _ := json.Marshal(newMember)
@@ -45,19 +47,19 @@ func TestMemberController_Register_Success(t *testing.T) {
 
 	// Then
 	assert.Equal(t, http.StatusCreated, resp.Code)
-	var response map[string]interface{}
-	err := json.Unmarshal(resp.Body.Bytes(), &response)
+	var responseData response.RegisterMemberResponse
+	err := json.Unmarshal(resp.Body.Bytes(), &responseData)
 	assert.NoError(t, err)
-	assert.Equal(t, "회원 가입이 완료되었습니다.", response["message"])
-	assert.NotEmpty(t, response["token"])
+	assert.Equal(t, "회원 가입이 완료되었습니다.", responseData.Message)
+	assert.Equal(t, "newuser", responseData.User.Username)
 }
 
 func TestMemberController_Register_Failure_InvalidRequest(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	router := gin.Default()
@@ -83,18 +85,17 @@ func TestMemberController_GetMyInfo_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	member := &domain.Member{
-		ID:             1234,
-		MemberNumber:   "P1234",
-		Username:       "testuser",
-		HashedPassword: "password123",
-		FullName:       "Test User",
-		Email:          "testuser@example.com",
+		MemberNumber: "M1234",
+		Username:     "testuser",
+		FullName:     "Test User",
+		Email:        "testuser@example.com",
 	}
+	member.SetPassword("password123")
 	_ = memberRepo.Create(member)
 
 	router := gin.Default()
@@ -111,18 +112,18 @@ func TestMemberController_GetMyInfo_Success(t *testing.T) {
 
 	// Then
 	assert.Equal(t, http.StatusOK, resp.Code)
-	var retrievedMember domain.Member
-	err := json.Unmarshal(resp.Body.Bytes(), &retrievedMember)
+	var responseData response.MemberResponse
+	err := json.Unmarshal(resp.Body.Bytes(), &responseData)
 	assert.NoError(t, err)
-	assert.Equal(t, "Test User", retrievedMember.FullName)
+	assert.Equal(t, "Test User", responseData.FullName)
 }
 
 func TestMemberController_GetMyInfo_Failure_UserNotFound(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	router := gin.Default()
@@ -145,18 +146,17 @@ func TestMemberController_UpdateMyInfo_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	member := &domain.Member{
-		ID:             1234,
-		MemberNumber:   "P1234",
-		Username:       "testuser",
-		HashedPassword: "password123",
-		FullName:       "Old Name",
-		Email:          "old@example.com",
+		MemberNumber: "M1234",
+		Username:     "testuser",
+		FullName:     "Old Name",
+		Email:        "old@example.com",
 	}
+	member.SetPassword("password123")
 	_ = memberRepo.Create(member)
 
 	router := gin.Default()
@@ -165,9 +165,9 @@ func TestMemberController_UpdateMyInfo_Success(t *testing.T) {
 		memberController.UpdateMyInfo(c)
 	})
 
-	updateData := map[string]interface{}{
-		"full_name": "New Name",
-		"email":     "new@example.com",
+	updateData := request.UpdateMemberRequest{
+		FullName: "New Name",
+		Email:    "new@example.com",
 	}
 	requestBody, _ := json.Marshal(updateData)
 	req, _ := http.NewRequest("PUT", "/me", bytes.NewBuffer(requestBody))
@@ -193,8 +193,8 @@ func TestMemberController_UpdateMyInfo_Failure_InvalidRequest(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	member := &domain.Member{
@@ -231,17 +231,17 @@ func TestMemberController_DeleteMyAccount_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	member := &domain.Member{
-		ID:             1234,
-		Username:       "testuser",
-		HashedPassword: "password123",
-		FullName:       "Test User",
-		Email:          "testuser@example.com",
+		MemberNumber: "M1234",
+		Username:     "testuser",
+		FullName:     "Test User",
+		Email:        "testuser@example.com",
 	}
+	member.SetPassword("password123")
 	_ = memberRepo.Create(member)
 
 	router := gin.Default()
@@ -272,24 +272,24 @@ func TestMemberController_GetAllMembers_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	member1 := &domain.Member{
-		ID:             1234,
-		Username:       "user1",
-		HashedPassword: "password123",
-		FullName:       "User One",
-		Email:          "user1@example.com",
+		MemberNumber: "M1234",
+		Username:     "user1",
+		FullName:     "User One",
+		Email:        "user1@example.com",
 	}
+	member1.SetPassword("password123")
 	member2 := &domain.Member{
-		ID:             1235,
-		Username:       "user2",
-		HashedPassword: "password123",
-		FullName:       "User Two",
-		Email:          "user2@example.com",
+		MemberNumber: "M1235",
+		Username:     "user2",
+		FullName:     "User Two",
+		Email:        "user2@example.com",
 	}
+	member2.SetPassword("password123")
 	_ = memberRepo.Create(member1)
 	_ = memberRepo.Create(member2)
 
@@ -307,18 +307,18 @@ func TestMemberController_GetAllMembers_Success(t *testing.T) {
 
 	// Then
 	assert.Equal(t, http.StatusOK, resp.Code)
-	var members []domain.Member
+	var members []*response.MemberResponse
 	err := json.Unmarshal(resp.Body.Bytes(), &members)
 	assert.NoError(t, err)
-	assert.Len(t, members, 1)
+	assert.Len(t, members, 2)
 }
 
 func TestMemberController_GetAllMembers_Failure_Unauthorized(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	memberInteractor := usecases.NewMemberInteractor(memberRepo)
 	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	memberInteractor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 	memberController := controller.NewMemberController(memberInteractor, authUseCase)
 
 	router := gin.Default()

--- a/internal/interfaces/controller/order_controller.go
+++ b/internal/interfaces/controller/order_controller.go
@@ -2,11 +2,8 @@ package controller
 
 import (
 	"net/http"
-	"time"
 
-	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
-	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 	"github.com/HongJungWan/commerce-system/internal/usecases"
 	"github.com/gin-gonic/gin"
 )
@@ -28,61 +25,22 @@ func (oc *OrderController) CreateOrder(c *gin.Context) {
 
 	memberNumber := c.GetString("member_number")
 
-	order := &domain.Order{
-		OrderNumber:   req.OrderNumber,
-		OrderDate:     time.Now(),
-		MemberNumber:  memberNumber,
-		ProductNumber: req.ProductNumber,
-		Quantity:      req.Quantity,
-	}
-
-	// 가격 및 총 금액은 비즈니스 로직에서 계산됩니다.
-	if err := oc.orderInteractor.CreateOrder(order); err != nil {
+	responseData, err := oc.orderInteractor.CreateOrder(&req, memberNumber)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	orderResponse := response.OrderResponse{
-		ID:            order.ID,
-		OrderNumber:   order.OrderNumber,
-		OrderDate:     order.OrderDate.Format(time.RFC3339),
-		MemberNumber:  order.MemberNumber,
-		ProductNumber: order.ProductNumber,
-		Price:         order.Price,
-		Quantity:      order.Quantity,
-		TotalAmount:   order.TotalAmount,
-		IsCanceled:    order.IsCanceled,
-		CanceledAt:    formatTime(order.CanceledAt),
-	}
-
-	c.JSON(http.StatusCreated, response.CreateOrderResponse{
-		Message: "주문이 등록되었습니다.",
-		Order:   orderResponse,
-	})
+	c.JSON(http.StatusCreated, responseData)
 }
 
 func (oc *OrderController) GetMyOrders(c *gin.Context) {
 	memberNumber := c.GetString("member_number")
-	orders, err := oc.orderInteractor.GetMyOrders(memberNumber)
+
+	orderResponses, err := oc.orderInteractor.GetMyOrders(memberNumber)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "주문 내역을 가져올 수 없습니다."})
 		return
-	}
-
-	var orderResponses []response.OrderResponse
-	for _, order := range orders {
-		orderResponses = append(orderResponses, response.OrderResponse{
-			ID:            order.ID,
-			OrderNumber:   order.OrderNumber,
-			OrderDate:     order.OrderDate.Format(time.RFC3339),
-			MemberNumber:  order.MemberNumber,
-			ProductNumber: order.ProductNumber,
-			Price:         order.Price,
-			Quantity:      order.Quantity,
-			TotalAmount:   order.TotalAmount,
-			IsCanceled:    order.IsCanceled,
-			CanceledAt:    formatTime(order.CanceledAt),
-		})
 	}
 
 	c.JSON(http.StatusOK, orderResponses)

--- a/internal/interfaces/controller/product_controller.go
+++ b/internal/interfaces/controller/product_controller.go
@@ -4,9 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
-	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 	"github.com/HongJungWan/commerce-system/internal/usecases"
 	"github.com/gin-gonic/gin"
 )
@@ -28,25 +26,13 @@ func (pc *ProductController) GetProducts(c *gin.Context) {
 		filter["product_name"] = name
 	}
 
-	products, err := pc.productInteractor.GetProducts(filter)
+	responseData, err := pc.productInteractor.GetProducts(filter)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "상품 목록을 가져올 수 없습니다."})
 		return
 	}
 
-	var productResponses []response.ProductResponse
-	for _, product := range products {
-		productResponses = append(productResponses, response.ProductResponse{
-			ID:            product.ID,
-			ProductNumber: product.ProductNumber,
-			ProductName:   product.ProductName,
-			Category:      product.Category,
-			Price:         product.Price,
-			StockQuantity: product.StockQuantity,
-		})
-	}
-
-	c.JSON(http.StatusOK, productResponses)
+	c.JSON(http.StatusOK, responseData)
 }
 
 func (pc *ProductController) CreateProduct(c *gin.Context) {
@@ -62,32 +48,13 @@ func (pc *ProductController) CreateProduct(c *gin.Context) {
 		return
 	}
 
-	product := &domain.Product{
-		ProductNumber: req.ProductNumber,
-		ProductName:   req.ProductName,
-		Category:      req.Category,
-		Price:         req.Price,
-		StockQuantity: req.StockQuantity,
-	}
-
-	if err := pc.productInteractor.CreateProduct(product); err != nil {
+	responseData, err := pc.productInteractor.CreateProduct(&req)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	productResponse := response.ProductResponse{
-		ID:            product.ID,
-		ProductNumber: product.ProductNumber,
-		ProductName:   product.ProductName,
-		Category:      product.Category,
-		Price:         product.Price,
-		StockQuantity: product.StockQuantity,
-	}
-
-	c.JSON(http.StatusCreated, response.CreateProductResponse{
-		Message: "상품이 등록되었습니다.",
-		Product: productResponse,
-	})
+	c.JSON(http.StatusCreated, responseData)
 }
 
 func (pc *ProductController) UpdateStock(c *gin.Context) {

--- a/internal/interfaces/controller/product_controller.go
+++ b/internal/interfaces/controller/product_controller.go
@@ -26,13 +26,13 @@ func (pc *ProductController) GetProducts(c *gin.Context) {
 		filter["product_name"] = name
 	}
 
-	responseData, err := pc.productInteractor.GetProducts(filter)
+	productResponses, err := pc.productInteractor.GetProducts(filter)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "상품 목록을 가져올 수 없습니다."})
 		return
 	}
 
-	c.JSON(http.StatusOK, responseData)
+	c.JSON(http.StatusOK, productResponses)
 }
 
 func (pc *ProductController) CreateProduct(c *gin.Context) {

--- a/internal/interfaces/dto/request/auth_request.go
+++ b/internal/interfaces/dto/request/auth_request.go
@@ -1,0 +1,6 @@
+package request
+
+type LoginRequest struct {
+	Username       string `json:"username"`
+	HashedPassword string `json:"hashed_password"`
+}

--- a/internal/interfaces/dto/request/member_request.go
+++ b/internal/interfaces/dto/request/member_request.go
@@ -1,5 +1,10 @@
 package request
 
+import (
+	"github.com/HongJungWan/commerce-system/internal/domain"
+	"time"
+)
+
 type RegisterMemberRequest struct {
 	MemberNumber string `json:"member_number"`
 	Username     string `json:"username"`
@@ -12,4 +17,40 @@ type UpdateMemberRequest struct {
 	FullName string `json:"full_name,omitempty"`
 	Email    string `json:"email,omitempty"`
 	Password string `json:"password,omitempty"`
+}
+
+func (req *RegisterMemberRequest) ToEntity() (*domain.Member, error) {
+	member := &domain.Member{
+		MemberNumber: req.MemberNumber,
+		Username:     req.Username,
+		FullName:     req.FullName,
+		Email:        req.Email,
+		CreatedAt:    time.Now(),
+	}
+
+	if err := member.SetPassword(req.Password); err != nil {
+		return nil, err
+	}
+
+	if err := member.Validate(); err != nil {
+		return nil, err
+	}
+
+	return member, nil
+}
+
+func (req *UpdateMemberRequest) ToEntity() (*domain.Member, error) {
+	member := &domain.Member{
+		FullName: req.FullName,
+		Email:    req.Email,
+	}
+
+	if req.Password != "" {
+		if err := member.SetPassword(req.Password); err != nil {
+			return nil, err
+		}
+	}
+
+	// 업데이트의 경우 필드가 선택적이므로 유효성 검사를 생략하거나 필요한 경우 추가
+	return member, nil
 }

--- a/internal/interfaces/dto/request/member_request.go
+++ b/internal/interfaces/dto/request/member_request.go
@@ -1,0 +1,15 @@
+package request
+
+type RegisterMemberRequest struct {
+	MemberNumber string `json:"member_number"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+	FullName     string `json:"full_name"`
+	Email        string `json:"email"`
+}
+
+type UpdateMemberRequest struct {
+	FullName string `json:"full_name,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Password string `json:"password,omitempty"`
+}

--- a/internal/interfaces/dto/request/order_request.go
+++ b/internal/interfaces/dto/request/order_request.go
@@ -1,5 +1,10 @@
 package request
 
+import (
+	"github.com/HongJungWan/commerce-system/internal/domain"
+	"time"
+)
+
 type CreateOrderRequest struct {
 	OrderNumber   string `json:"order_number"`
 	ProductNumber string `json:"product_number"`
@@ -8,4 +13,20 @@ type CreateOrderRequest struct {
 
 type CancelOrderRequest struct {
 	OrderNumber string `json:"order_number"`
+}
+
+func (req *CreateOrderRequest) ToEntity(memberNumber string) (*domain.Order, error) {
+	order := &domain.Order{
+		OrderNumber:   req.OrderNumber,
+		OrderDate:     time.Now(),
+		MemberNumber:  memberNumber,
+		ProductNumber: req.ProductNumber,
+		Quantity:      req.Quantity,
+	}
+
+	if err := order.Validate(); err != nil {
+		return nil, err
+	}
+
+	return order, nil
 }

--- a/internal/interfaces/dto/request/order_request.go
+++ b/internal/interfaces/dto/request/order_request.go
@@ -1,0 +1,11 @@
+package request
+
+type CreateOrderRequest struct {
+	OrderNumber   string `json:"order_number"`
+	ProductNumber string `json:"product_number"`
+	Quantity      int    `json:"quantity"`
+}
+
+type CancelOrderRequest struct {
+	OrderNumber string `json:"order_number"`
+}

--- a/internal/interfaces/dto/request/product_request.go
+++ b/internal/interfaces/dto/request/product_request.go
@@ -1,0 +1,13 @@
+package request
+
+type CreateProductRequest struct {
+	ProductNumber string `json:"product_number"`
+	ProductName   string `json:"product_name"`
+	Category      string `json:"category"`
+	Price         int64  `json:"price"`
+	StockQuantity int    `json:"stock_quantity"`
+}
+
+type UpdateStockRequest struct {
+	StockQuantity int `json:"stock_quantity"`
+}

--- a/internal/interfaces/dto/request/product_request.go
+++ b/internal/interfaces/dto/request/product_request.go
@@ -1,5 +1,7 @@
 package request
 
+import "github.com/HongJungWan/commerce-system/internal/domain"
+
 type CreateProductRequest struct {
 	ProductNumber string `json:"product_number"`
 	ProductName   string `json:"product_name"`
@@ -10,4 +12,20 @@ type CreateProductRequest struct {
 
 type UpdateStockRequest struct {
 	StockQuantity int `json:"stock_quantity"`
+}
+
+func (req *CreateProductRequest) ToEntity() (*domain.Product, error) {
+	product := &domain.Product{
+		ProductNumber: req.ProductNumber,
+		ProductName:   req.ProductName,
+		Category:      req.Category,
+		Price:         req.Price,
+		StockQuantity: req.StockQuantity,
+	}
+
+	if err := product.Validate(); err != nil {
+		return nil, err
+	}
+
+	return product, nil
 }

--- a/internal/interfaces/dto/response/auth_response.go
+++ b/internal/interfaces/dto/response/auth_response.go
@@ -1,0 +1,5 @@
+package response
+
+type LoginResponse struct {
+	Token string `json:"token"`
+}

--- a/internal/interfaces/dto/response/member_response.go
+++ b/internal/interfaces/dto/response/member_response.go
@@ -1,5 +1,11 @@
 package response
 
+import (
+	"github.com/HongJungWan/commerce-system/internal/domain"
+	"github.com/HongJungWan/commerce-system/internal/helper"
+	"time"
+)
+
 type MemberResponse struct {
 	ID           uint   `json:"id"`
 	MemberNumber string `json:"member_number"`
@@ -13,7 +19,20 @@ type MemberResponse struct {
 }
 
 type RegisterMemberResponse struct {
-	Message string          `json:"message"`
-	Token   string          `json:"token"`
-	User    *MemberResponse `json:"user"`
+	Message string         `json:"message"`
+	User    MemberResponse `json:"user"`
+}
+
+func NewMemberResponse(member *domain.Member) *MemberResponse {
+	return &MemberResponse{
+		ID:           member.ID,
+		MemberNumber: member.MemberNumber,
+		Username:     member.Username,
+		FullName:     member.FullName,
+		Email:        member.Email,
+		CreatedAt:    member.CreatedAt.Format(time.RFC3339),
+		IsAdmin:      member.IsAdmin,
+		IsWithdrawn:  member.IsWithdrawn,
+		WithdrawnAt:  helper.FormatTime(member.WithdrawnAt),
+	}
 }

--- a/internal/interfaces/dto/response/member_response.go
+++ b/internal/interfaces/dto/response/member_response.go
@@ -1,0 +1,19 @@
+package response
+
+type MemberResponse struct {
+	ID           uint   `json:"id"`
+	MemberNumber string `json:"member_number"`
+	Username     string `json:"username"`
+	FullName     string `json:"full_name"`
+	Email        string `json:"email"`
+	CreatedAt    string `json:"created_at"`
+	IsAdmin      bool   `json:"is_admin"`
+	IsWithdrawn  bool   `json:"is_withdrawn"`
+	WithdrawnAt  string `json:"withdrawn_at,omitempty"`
+}
+
+type RegisterMemberResponse struct {
+	Message string         `json:"message"`
+	Token   string         `json:"token"`
+	User    MemberResponse `json:"user"`
+}

--- a/internal/interfaces/dto/response/member_response.go
+++ b/internal/interfaces/dto/response/member_response.go
@@ -13,7 +13,7 @@ type MemberResponse struct {
 }
 
 type RegisterMemberResponse struct {
-	Message string         `json:"message"`
-	Token   string         `json:"token"`
-	User    MemberResponse `json:"user"`
+	Message string          `json:"message"`
+	Token   string          `json:"token"`
+	User    *MemberResponse `json:"user"`
 }

--- a/internal/interfaces/dto/response/order_response.go
+++ b/internal/interfaces/dto/response/order_response.go
@@ -1,0 +1,19 @@
+package response
+
+type OrderResponse struct {
+	ID            int    `json:"id"`
+	OrderNumber   string `json:"order_number"`
+	OrderDate     string `json:"order_date"`
+	MemberNumber  string `json:"member_number"`
+	ProductNumber string `json:"product_number"`
+	Price         int64  `json:"price"`
+	Quantity      int    `json:"quantity"`
+	TotalAmount   int64  `json:"total_amount"`
+	IsCanceled    bool   `json:"is_canceled"`
+	CanceledAt    string `json:"canceled_at,omitempty"`
+}
+
+type CreateOrderResponse struct {
+	Message string        `json:"message"`
+	Order   OrderResponse `json:"order"`
+}

--- a/internal/interfaces/dto/response/order_response.go
+++ b/internal/interfaces/dto/response/order_response.go
@@ -1,5 +1,11 @@
 package response
 
+import (
+	"github.com/HongJungWan/commerce-system/internal/domain"
+	"github.com/HongJungWan/commerce-system/internal/helper"
+	"time"
+)
+
 type OrderResponse struct {
 	ID            int    `json:"id"`
 	OrderNumber   string `json:"order_number"`
@@ -16,4 +22,19 @@ type OrderResponse struct {
 type CreateOrderResponse struct {
 	Message string        `json:"message"`
 	Order   OrderResponse `json:"order"`
+}
+
+func NewOrderResponse(order *domain.Order) *OrderResponse {
+	return &OrderResponse{
+		ID:            order.ID,
+		OrderNumber:   order.OrderNumber,
+		OrderDate:     order.OrderDate.Format(time.RFC3339),
+		MemberNumber:  order.MemberNumber,
+		ProductNumber: order.ProductNumber,
+		Price:         order.Price,
+		Quantity:      order.Quantity,
+		TotalAmount:   order.TotalAmount,
+		IsCanceled:    order.IsCanceled,
+		CanceledAt:    helper.FormatTime(order.CanceledAt),
+	}
 }

--- a/internal/interfaces/dto/response/product_response.go
+++ b/internal/interfaces/dto/response/product_response.go
@@ -10,6 +10,6 @@ type ProductResponse struct {
 }
 
 type CreateProductResponse struct {
-	Message string          `json:"message"`
-	Product ProductResponse `json:"product"`
+	Message string           `json:"message"`
+	Product *ProductResponse `json:"product"`
 }

--- a/internal/interfaces/dto/response/product_response.go
+++ b/internal/interfaces/dto/response/product_response.go
@@ -1,0 +1,15 @@
+package response
+
+type ProductResponse struct {
+	ID            int    `json:"id"`
+	ProductNumber string `json:"product_number"`
+	ProductName   string `json:"product_name"`
+	Category      string `json:"category"`
+	Price         int64  `json:"price"`
+	StockQuantity int    `json:"stock_quantity"`
+}
+
+type CreateProductResponse struct {
+	Message string          `json:"message"`
+	Product ProductResponse `json:"product"`
+}

--- a/internal/interfaces/dto/response/product_response.go
+++ b/internal/interfaces/dto/response/product_response.go
@@ -1,5 +1,7 @@
 package response
 
+import "github.com/HongJungWan/commerce-system/internal/domain"
+
 type ProductResponse struct {
 	ID            int    `json:"id"`
 	ProductNumber string `json:"product_number"`
@@ -10,6 +12,17 @@ type ProductResponse struct {
 }
 
 type CreateProductResponse struct {
-	Message string           `json:"message"`
-	Product *ProductResponse `json:"product"`
+	Message string          `json:"message"`
+	Product ProductResponse `json:"product"`
+}
+
+func NewProductResponse(product *domain.Product) *ProductResponse {
+	return &ProductResponse{
+		ID:            product.ID,
+		ProductNumber: product.ProductNumber,
+		ProductName:   product.ProductName,
+		Category:      product.Category,
+		Price:         product.Price,
+		StockQuantity: product.StockQuantity,
+	}
 }

--- a/internal/usecases/member_interactor.go
+++ b/internal/usecases/member_interactor.go
@@ -2,9 +2,7 @@ package usecases
 
 import (
 	"errors"
-	"time"
 
-	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/domain/repository"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
@@ -23,9 +21,8 @@ func NewMemberInteractor(repo repository.MemberRepository, auth *AuthUseCase) *M
 }
 
 func (mi *MemberInteractor) Register(req *request.RegisterMemberRequest) (*response.RegisterMemberResponse, error) {
-	member := mi.toEntity(req)
-
-	if err := member.Validate(); err != nil {
+	member, err := req.ToEntity()
+	if err != nil {
 		return nil, err
 	}
 
@@ -34,20 +31,15 @@ func (mi *MemberInteractor) Register(req *request.RegisterMemberRequest) (*respo
 		return nil, errors.New("이미 존재하는 사용자 ID입니다.")
 	}
 
-	if err := member.SetPassword(req.Password); err != nil {
-		return nil, err
-	}
-
 	if err := mi.MemberRepository.Create(member); err != nil {
 		return nil, err
 	}
 
-	token, _ := mi.AuthUseCase.GenerateToken(member)
+	memberResponse := response.NewMemberResponse(member)
 
 	return &response.RegisterMemberResponse{
 		Message: "회원 가입이 완료되었습니다.",
-		Token:   token,
-		User:    mi.toDTO(member),
+		User:    *memberResponse,
 	}, nil
 }
 
@@ -57,7 +49,8 @@ func (mi *MemberInteractor) GetMyInfo(username string) (*response.MemberResponse
 		return nil, err
 	}
 
-	return mi.toDTO(member), nil
+	memberResponse := response.NewMemberResponse(member)
+	return memberResponse, nil
 }
 
 func (mi *MemberInteractor) UpdateMyInfo(username string, req *request.UpdateMemberRequest) error {
@@ -97,7 +90,7 @@ func (mi *MemberInteractor) GetAllMembers() ([]*response.MemberResponse, error) 
 
 	var memberResponses []*response.MemberResponse
 	for _, member := range members {
-		memberResponses = append(memberResponses, mi.toDTO(member))
+		memberResponses = append(memberResponses, response.NewMemberResponse(member))
 	}
 
 	return memberResponses, nil
@@ -115,35 +108,4 @@ func (mi *MemberInteractor) GetMemberStats(month string) (map[string]interface{}
 		"deleted_members": deleted,
 	}
 	return stats, nil
-}
-
-func (mi *MemberInteractor) toEntity(req *request.RegisterMemberRequest) *domain.Member {
-	return &domain.Member{
-		MemberNumber: req.MemberNumber,
-		Username:     req.Username,
-		FullName:     req.FullName,
-		Email:        req.Email,
-		CreatedAt:    time.Now(),
-	}
-}
-
-func (mi *MemberInteractor) toDTO(member *domain.Member) *response.MemberResponse {
-	return &response.MemberResponse{
-		ID:           member.ID,
-		MemberNumber: member.MemberNumber,
-		Username:     member.Username,
-		FullName:     member.FullName,
-		Email:        member.Email,
-		CreatedAt:    member.CreatedAt.Format(time.RFC3339),
-		IsAdmin:      member.IsAdmin,
-		IsWithdrawn:  member.IsWithdrawn,
-		WithdrawnAt:  formatTime(member.WithdrawnAt),
-	}
-}
-
-func formatTime(t *time.Time) string {
-	if t == nil {
-		return ""
-	}
-	return t.Format(time.RFC3339)
 }

--- a/internal/usecases/member_interactor.go
+++ b/internal/usecases/member_interactor.go
@@ -32,12 +32,12 @@ func (mi *MemberInteractor) Register(member *domain.Member) error {
 	return mi.MemberRepository.Create(member)
 }
 
-func (mi *MemberInteractor) GetByUserName(userID string) (*domain.Member, error) {
-	return mi.MemberRepository.GetByUserName(userID)
+func (mi *MemberInteractor) GetByUserName(userName string) (*domain.Member, error) {
+	return mi.MemberRepository.GetByUserName(userName)
 }
 
-func (mi *MemberInteractor) UpdateByUserID(userID string, updateData *domain.Member) error {
-	member, err := mi.MemberRepository.GetByUserName(userID)
+func (mi *MemberInteractor) UpdateByUserName(userName string, updateData *domain.Member) error {
+	member, err := mi.MemberRepository.GetByUserName(userName)
 	if err != nil {
 		return err
 	}
@@ -57,8 +57,8 @@ func (mi *MemberInteractor) UpdateByUserID(userID string, updateData *domain.Mem
 	return mi.MemberRepository.Update(member)
 }
 
-func (mi *MemberInteractor) DeleteByUserID(userID string) error {
-	member, err := mi.MemberRepository.GetByUserName(userID)
+func (mi *MemberInteractor) DeleteByUserName(userName string) error {
+	member, err := mi.MemberRepository.GetByUserName(userName)
 	if err != nil {
 		return err
 	}

--- a/internal/usecases/member_interactor.go
+++ b/internal/usecases/member_interactor.go
@@ -2,54 +2,78 @@ package usecases
 
 import (
 	"errors"
+	"time"
 
 	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/domain/repository"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 )
 
 type MemberInteractor struct {
 	MemberRepository repository.MemberRepository
+	AuthUseCase      *AuthUseCase
 }
 
-func NewMemberInteractor(repo repository.MemberRepository) *MemberInteractor {
-	return &MemberInteractor{MemberRepository: repo}
+func NewMemberInteractor(repo repository.MemberRepository, auth *AuthUseCase) *MemberInteractor {
+	return &MemberInteractor{
+		MemberRepository: repo,
+		AuthUseCase:      auth,
+	}
 }
 
-func (mi *MemberInteractor) Register(member *domain.Member) error {
+func (mi *MemberInteractor) Register(req *request.RegisterMemberRequest) (*response.RegisterMemberResponse, error) {
+	member := mi.toEntity(req)
+
 	if err := member.Validate(); err != nil {
-		return err
+		return nil, err
 	}
 
 	existingMember, _ := mi.MemberRepository.GetByUserName(member.Username)
 	if existingMember != nil {
-		return errors.New("이미 존재하는 사용자 ID입니다.")
+		return nil, errors.New("이미 존재하는 사용자 ID입니다.")
 	}
 
-	if err := member.SetPassword(member.HashedPassword); err != nil {
-		return err
+	if err := member.SetPassword(req.Password); err != nil {
+		return nil, err
 	}
 
-	return mi.MemberRepository.Create(member)
+	if err := mi.MemberRepository.Create(member); err != nil {
+		return nil, err
+	}
+
+	token, _ := mi.AuthUseCase.GenerateToken(member)
+
+	return &response.RegisterMemberResponse{
+		Message: "회원 가입이 완료되었습니다.",
+		Token:   token,
+		User:    mi.toDTO(member),
+	}, nil
 }
 
-func (mi *MemberInteractor) GetByUserName(userName string) (*domain.Member, error) {
-	return mi.MemberRepository.GetByUserName(userName)
+func (mi *MemberInteractor) GetMyInfo(username string) (*response.MemberResponse, error) {
+	member, err := mi.MemberRepository.GetByUserName(username)
+	if err != nil {
+		return nil, err
+	}
+
+	return mi.toDTO(member), nil
 }
 
-func (mi *MemberInteractor) UpdateByUserName(userName string, updateData *domain.Member) error {
-	member, err := mi.MemberRepository.GetByUserName(userName)
+func (mi *MemberInteractor) UpdateMyInfo(username string, req *request.UpdateMemberRequest) error {
+	member, err := mi.MemberRepository.GetByUserName(username)
 	if err != nil {
 		return err
 	}
 
-	if updateData.FullName != "" {
-		member.FullName = updateData.FullName
+	if req.FullName != "" {
+		member.FullName = req.FullName
 	}
-	if updateData.Email != "" {
-		member.Email = updateData.Email
+	if req.Email != "" {
+		member.Email = req.Email
 	}
-	if updateData.HashedPassword != "" {
-		if err := member.SetPassword(updateData.HashedPassword); err != nil {
+	if req.Password != "" {
+		if err := member.SetPassword(req.Password); err != nil {
 			return err
 		}
 	}
@@ -57,18 +81,69 @@ func (mi *MemberInteractor) UpdateByUserName(userName string, updateData *domain
 	return mi.MemberRepository.Update(member)
 }
 
-func (mi *MemberInteractor) DeleteByUserName(userName string) error {
-	member, err := mi.MemberRepository.GetByUserName(userName)
+func (mi *MemberInteractor) DeleteByUserName(username string) error {
+	member, err := mi.MemberRepository.GetByUserName(username)
 	if err != nil {
 		return err
 	}
 	return mi.MemberRepository.Delete(member.ID)
 }
 
-func (mi *MemberInteractor) GetAll() ([]*domain.Member, error) {
-	return mi.MemberRepository.GetAll()
+func (mi *MemberInteractor) GetAllMembers() ([]*response.MemberResponse, error) {
+	members, err := mi.MemberRepository.GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var memberResponses []*response.MemberResponse
+	for _, member := range members {
+		memberResponses = append(memberResponses, mi.toDTO(member))
+	}
+
+	return memberResponses, nil
 }
 
-func (mi *MemberInteractor) GetStatsByMonth(month string) (int, int, error) {
-	return mi.MemberRepository.GetStatsByMonth(month)
+func (mi *MemberInteractor) GetMemberStats(month string) (map[string]interface{}, error) {
+	joined, deleted, err := mi.MemberRepository.GetStatsByMonth(month)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := map[string]interface{}{
+		"month":           month,
+		"joined_members":  joined,
+		"deleted_members": deleted,
+	}
+	return stats, nil
+}
+
+func (mi *MemberInteractor) toEntity(req *request.RegisterMemberRequest) *domain.Member {
+	return &domain.Member{
+		MemberNumber: req.MemberNumber,
+		Username:     req.Username,
+		FullName:     req.FullName,
+		Email:        req.Email,
+		CreatedAt:    time.Now(),
+	}
+}
+
+func (mi *MemberInteractor) toDTO(member *domain.Member) *response.MemberResponse {
+	return &response.MemberResponse{
+		ID:           member.ID,
+		MemberNumber: member.MemberNumber,
+		Username:     member.Username,
+		FullName:     member.FullName,
+		Email:        member.Email,
+		CreatedAt:    member.CreatedAt.Format(time.RFC3339),
+		IsAdmin:      member.IsAdmin,
+		IsWithdrawn:  member.IsWithdrawn,
+		WithdrawnAt:  formatTime(member.WithdrawnAt),
+	}
+}
+
+func formatTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
 }

--- a/internal/usecases/member_interactor_test.go
+++ b/internal/usecases/member_interactor_test.go
@@ -123,7 +123,7 @@ func TestMemberInteractor_UpdateByUserID_Success(t *testing.T) {
 	}
 
 	// When
-	err := interactor.UpdateByUserID("testuser", updateData)
+	err := interactor.UpdateByUserName("testuser", updateData)
 
 	// Then
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestMemberInteractor_UpdateByUserID_Failure_UserNotFound(t *testing.T) {
 	}
 
 	// When
-	err := interactor.UpdateByUserID("nonexistent", updateData)
+	err := interactor.UpdateByUserName("nonexistent", updateData)
 
 	// Then
 	assert.Error(t, err)
@@ -166,7 +166,7 @@ func TestMemberInteractor_DeleteByUserID_Success(t *testing.T) {
 	_ = memberRepo.Create(member)
 
 	// When
-	err := interactor.DeleteByUserID("testuser")
+	err := interactor.DeleteByUserName("testuser")
 
 	// Then
 	assert.NoError(t, err)
@@ -182,7 +182,7 @@ func TestMemberInteractor_DeleteByUserID_Failure_UserNotFound(t *testing.T) {
 	interactor := usecases.NewMemberInteractor(memberRepo)
 
 	// When
-	err := interactor.DeleteByUserID("nonexistent")
+	err := interactor.DeleteByUserName("nonexistent")
 
 	// Then
 	assert.Error(t, err)

--- a/internal/usecases/member_interactor_test.go
+++ b/internal/usecases/member_interactor_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/infrastructure/repository"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
 	"github.com/HongJungWan/commerce-system/internal/usecases"
 	"github.com/HongJungWan/commerce-system/test/fixtures"
 	"github.com/stretchr/testify/assert"
@@ -15,21 +16,23 @@ func TestMemberInteractor_Register_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
-	member := &domain.Member{
-		Username:       "newuser",
-		HashedPassword: "password123",
-		FullName:       "New User",
-		Email:          "newuser@example.com",
-		MemberNumber:   "M12345",
+	req := &request.RegisterMemberRequest{
+		MemberNumber: "M12345",
+		Username:     "newuser",
+		Password:     "password123",
+		FullName:     "New User",
+		Email:        "newuser@example.com",
 	}
 
 	// When
-	err := interactor.Register(member)
+	responseData, err := interactor.Register(req)
 
 	// Then
 	assert.NoError(t, err)
+	assert.Equal(t, "회원 가입이 완료되었습니다.", responseData.Message)
 	retrievedMember, _ := memberRepo.GetByUserName("newuser")
 	assert.NotNil(t, retrievedMember)
 }
@@ -38,92 +41,96 @@ func TestMemberInteractor_Register_Failure_DuplicateUserID(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	existingMember := &domain.Member{
-		Username:       "duplicateuser",
-		HashedPassword: "password123",
-		FullName:       "Existing User",
-		Email:          "existing@example.com",
-		MemberNumber:   "M12345",
+		MemberNumber: "M12345",
+		Username:     "duplicateuser",
+		FullName:     "Existing User",
+		Email:        "existing@example.com",
 	}
+	existingMember.SetPassword("password123")
 	_ = memberRepo.Create(existingMember)
 
-	newMember := &domain.Member{
-		Username:       "duplicateuser",
-		HashedPassword: "password456",
-		FullName:       "New User",
-		Email:          "new@example.com",
-		MemberNumber:   "M12346",
+	req := &request.RegisterMemberRequest{
+		MemberNumber: "M12346",
+		Username:     "duplicateuser",
+		Password:     "password456",
+		FullName:     "New User",
+		Email:        "new@example.com",
 	}
 
 	// When
-	err := interactor.Register(newMember)
+	_, err := interactor.Register(req)
 
 	// Then
 	assert.Error(t, err)
 	assert.Equal(t, "이미 존재하는 사용자 ID입니다.", err.Error())
 }
 
-func TestMemberInteractor_GetByUserID_Success(t *testing.T) {
+func TestMemberInteractor_GetMyInfo_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	member := &domain.Member{
-		Username:       "testuser",
-		HashedPassword: "password123",
-		FullName:       "Test User",
-		Email:          "testuser@example.com",
-		MemberNumber:   "M12345",
+		MemberNumber: "M12345",
+		Username:     "testuser",
+		FullName:     "Test User",
+		Email:        "testuser@example.com",
 	}
+	member.SetPassword("password123")
 	_ = memberRepo.Create(member)
 
 	// When
-	retrievedMember, err := interactor.GetByUserName("testuser")
+	memberResponse, err := interactor.GetMyInfo("testuser")
 
 	// Then
 	assert.NoError(t, err)
-	assert.Equal(t, member.FullName, retrievedMember.FullName)
+	assert.Equal(t, member.FullName, memberResponse.FullName)
 }
 
-func TestMemberInteractor_GetByUserID_Failure_NotFound(t *testing.T) {
+func TestMemberInteractor_GetMyInfo_Failure_NotFound(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	// When
-	retrievedMember, err := interactor.GetByUserName("nonexistent")
+	memberResponse, err := interactor.GetMyInfo("nonexistent")
 
 	// Then
 	assert.Error(t, err)
-	assert.Nil(t, retrievedMember)
+	assert.Nil(t, memberResponse)
 }
 
-func TestMemberInteractor_UpdateByUserID_Success(t *testing.T) {
+func TestMemberInteractor_UpdateMyInfo_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	member := &domain.Member{
-		Username:       "testuser",
-		HashedPassword: "password123",
-		FullName:       "Old Name",
-		Email:          "old@example.com",
-		MemberNumber:   "M12345",
+		MemberNumber: "M12345",
+		Username:     "testuser",
+		FullName:     "Old Name",
+		Email:        "old@example.com",
 	}
+	member.SetPassword("password123")
 	_ = memberRepo.Create(member)
 
-	updateData := &domain.Member{
+	updateReq := &request.UpdateMemberRequest{
 		FullName: "New Name",
 		Email:    "new@example.com",
 	}
 
 	// When
-	err := interactor.UpdateByUserName("testuser", updateData)
+	err := interactor.UpdateMyInfo("testuser", updateReq)
 
 	// Then
 	assert.NoError(t, err)
@@ -132,37 +139,39 @@ func TestMemberInteractor_UpdateByUserID_Success(t *testing.T) {
 	assert.Equal(t, "new@example.com", updatedMember.Email)
 }
 
-func TestMemberInteractor_UpdateByUserID_Failure_UserNotFound(t *testing.T) {
+func TestMemberInteractor_UpdateMyInfo_Failure_UserNotFound(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
-	updateData := &domain.Member{
+	updateReq := &request.UpdateMemberRequest{
 		FullName: "New Name",
 		Email:    "new@example.com",
 	}
 
 	// When
-	err := interactor.UpdateByUserName("nonexistent", updateData)
+	err := interactor.UpdateMyInfo("nonexistent", updateReq)
 
 	// Then
 	assert.Error(t, err)
 }
 
-func TestMemberInteractor_DeleteByUserID_Success(t *testing.T) {
+func TestMemberInteractor_DeleteByUserName_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	member := &domain.Member{
-		Username:       "testuser",
-		HashedPassword: "password123",
-		FullName:       "Test User",
-		Email:          "testuser@example.com",
-		MemberNumber:   "M12345",
+		MemberNumber: "M12345",
+		Username:     "testuser",
+		FullName:     "Test User",
+		Email:        "testuser@example.com",
 	}
+	member.SetPassword("password123")
 	_ = memberRepo.Create(member)
 
 	// When
@@ -175,11 +184,12 @@ func TestMemberInteractor_DeleteByUserID_Success(t *testing.T) {
 	assert.Nil(t, deletedMember)
 }
 
-func TestMemberInteractor_DeleteByUserID_Failure_UserNotFound(t *testing.T) {
+func TestMemberInteractor_DeleteByUserName_Failure_UserNotFound(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	// When
 	err := interactor.DeleteByUserName("nonexistent")
@@ -188,83 +198,85 @@ func TestMemberInteractor_DeleteByUserID_Failure_UserNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestMemberInteractor_GetAll_Success(t *testing.T) {
+func TestMemberInteractor_GetAllMembers_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	member1 := &domain.Member{
-		Username:       "user1",
-		HashedPassword: "password123",
-		FullName:       "User One",
-		Email:          "user1@example.com",
-		MemberNumber:   "M12345",
+		MemberNumber: "M12345",
+		Username:     "user1",
+		FullName:     "User One",
+		Email:        "user1@example.com",
 	}
+	member1.SetPassword("password123")
 	member2 := &domain.Member{
-		Username:       "user2",
-		HashedPassword: "password123",
-		FullName:       "User Two",
-		Email:          "user2@example.com",
-		MemberNumber:   "M12346",
+		MemberNumber: "M12346",
+		Username:     "user2",
+		FullName:     "User Two",
+		Email:        "user2@example.com",
 	}
+	member2.SetPassword("password123")
 	_ = memberRepo.Create(member1)
 	_ = memberRepo.Create(member2)
 
 	// When
-	members, err := interactor.GetAll()
+	members, err := interactor.GetAllMembers()
 
 	// Then
 	assert.NoError(t, err)
 	assert.Len(t, members, 2)
 }
 
-func TestMemberInteractor_GetStatsByMonth_Success(t *testing.T) {
+func TestMemberInteractor_GetMemberStats_Success(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	member1 := &domain.Member{
-		Username:       "user1",
-		HashedPassword: "password123",
-		FullName:       "User One",
-		Email:          "user1@example.com",
-		MemberNumber:   "M12345",
-		CreatedAt:      time.Date(2024, 9, 10, 0, 0, 0, 0, time.UTC),
+		MemberNumber: "M12345",
+		Username:     "user1",
+		FullName:     "User One",
+		Email:        "user1@example.com",
+		CreatedAt:    time.Date(2024, 9, 10, 0, 0, 0, 0, time.UTC),
 	}
+	member1.SetPassword("password123")
 	member2 := &domain.Member{
-		Username:       "user2",
-		HashedPassword: "password123",
-		FullName:       "User Two",
-		Email:          "user2@example.com",
-		MemberNumber:   "M12346",
-		CreatedAt:      time.Date(2024, 9, 15, 0, 0, 0, 0, time.UTC),
+		MemberNumber: "M12346",
+		Username:     "user2",
+		FullName:     "User Two",
+		Email:        "user2@example.com",
+		CreatedAt:    time.Date(2024, 9, 15, 0, 0, 0, 0, time.UTC),
 	}
+	member2.SetPassword("password123")
 	_ = memberRepo.Create(member1)
 	_ = memberRepo.Create(member2)
 	_ = memberRepo.Delete(member2.ID)
 
 	// When
-	joined, deleted, err := interactor.GetStatsByMonth("2024-09")
+	stats, err := interactor.GetMemberStats("2024-09")
 
 	// Then
 	assert.NoError(t, err)
-	assert.Equal(t, 1, joined)
-	assert.Equal(t, 0, deleted)
+	assert.Equal(t, 2, stats["joined_members"])
+	assert.Equal(t, 1, stats["deleted_members"])
 }
 
-func TestMemberInteractor_GetStatsByMonth_Failure_InvalidMonth(t *testing.T) {
+func TestMemberInteractor_GetMemberStats_Failure_InvalidMonth(t *testing.T) {
 	// Given
 	db := fixtures.SetupTestDB()
 	memberRepo := repository.NewMemberRepository(db)
-	interactor := usecases.NewMemberInteractor(memberRepo)
+	authUseCase := usecases.NewAuthUseCase("secret", memberRepo)
+	interactor := usecases.NewMemberInteractor(memberRepo, authUseCase)
 
 	// When
-	joined, deleted, err := interactor.GetStatsByMonth("invalid-month")
+	stats, err := interactor.GetMemberStats("invalid-month")
 
 	// Then
 	assert.Error(t, err)
-	assert.Equal(t, 0, joined)
-	assert.Equal(t, 0, deleted)
+	assert.Nil(t, stats)
 }

--- a/internal/usecases/order_interactor.go
+++ b/internal/usecases/order_interactor.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/domain/repository"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 )
 
 type OrderInteractor struct {
@@ -22,45 +24,71 @@ func NewOrderInteractor(or repository.OrderRepository, mr repository.MemberRepos
 	}
 }
 
-func (oi *OrderInteractor) CreateOrder(order *domain.Order) error {
-	if err := order.Validate(); err != nil {
-		return err
+// CreateOrder는 주문을 생성하고 응답 DTO를 반환합니다.
+func (oi *OrderInteractor) CreateOrder(req *request.CreateOrderRequest, memberNumber string) (*response.CreateOrderResponse, error) {
+	// 요청 DTO를 도메인 엔티티로 변환
+	order, err := oi.toEntity(req, memberNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	// 회원 확인
-	member, err := oi.MemberRepository.GetByMemberNumber(order.MemberNumber)
+	member, err := oi.MemberRepository.GetByMemberNumber(memberNumber)
 	if err != nil || member == nil {
-		return errors.New("유효하지 않은 회원 번호입니다.")
+		return nil, errors.New("유효하지 않은 회원 번호입니다.")
 	}
 
 	// 상품 확인
 	product, err := oi.ProductRepository.GetByProductNumber(order.ProductNumber)
 	if err != nil || product == nil {
-		return errors.New("유효하지 않은 상품 번호입니다.")
+		return nil, errors.New("유효하지 않은 상품 번호입니다.")
 	}
 
 	// 재고 확인 및 감소
 	if product.StockQuantity < order.Quantity {
-		return errors.New("재고 수량이 부족합니다.")
+		return nil, errors.New("재고 수량이 부족합니다.")
 	}
 	product.StockQuantity -= order.Quantity
 	if err := oi.ProductRepository.Update(product); err != nil {
-		return err
+		return nil, err
 	}
 
 	// 주문 가격 설정
 	order.Price = product.Price
 	order.TotalAmount = product.Price * int64(order.Quantity)
 	order.OrderDate = time.Now()
-	order.IsCanceled = true
+	order.IsCanceled = false
 
-	return oi.OrderRepository.Create(order)
+	// 주문 저장
+	if err := oi.OrderRepository.Create(order); err != nil {
+		return nil, err
+	}
+
+	// 도메인 엔티티를 응답 DTO로 변환
+	orderResponse := oi.toDTO(order)
+
+	return &response.CreateOrderResponse{
+		Message: "주문이 등록되었습니다.",
+		Order:   *orderResponse,
+	}, nil
 }
 
-func (oi *OrderInteractor) GetMyOrders(memberNumber string) ([]*domain.Order, error) {
-	return oi.OrderRepository.GetByMemberNumber(memberNumber)
+// GetMyOrders는 회원의 주문 목록을 응답 DTO로 반환합니다.
+func (oi *OrderInteractor) GetMyOrders(memberNumber string) ([]response.OrderResponse, error) {
+	orders, err := oi.OrderRepository.GetByMemberNumber(memberNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	var orderResponses []response.OrderResponse
+	for _, order := range orders {
+		orderResponses = append(orderResponses, *oi.toDTO(order))
+	}
+
+	return orderResponses, nil
 }
 
+// CancelOrder는 주문을 취소합니다.
 func (oi *OrderInteractor) CancelOrder(orderNumber, memberNumber string) error {
 	order, err := oi.OrderRepository.GetByOrderNumber(orderNumber)
 	if err != nil {
@@ -88,6 +116,40 @@ func (oi *OrderInteractor) CancelOrder(orderNumber, memberNumber string) error {
 	return oi.OrderRepository.Update(order)
 }
 
+// GetMonthlyStats는 월별 통계 정보를 반환합니다.
 func (oi *OrderInteractor) GetMonthlyStats(month string) (int64, int64, error) {
 	return oi.OrderRepository.GetMonthlyStats(month)
+}
+
+// 요청 DTO를 도메인 엔티티로 변환
+func (oi *OrderInteractor) toEntity(req *request.CreateOrderRequest, memberNumber string) (*domain.Order, error) {
+	order := &domain.Order{
+		OrderNumber:   req.OrderNumber,
+		OrderDate:     time.Now(),
+		MemberNumber:  memberNumber,
+		ProductNumber: req.ProductNumber,
+		Quantity:      req.Quantity,
+	}
+
+	if err := order.Validate(); err != nil {
+		return nil, err
+	}
+
+	return order, nil
+}
+
+// 도메인 엔티티를 응답 DTO로 변환
+func (oi *OrderInteractor) toDTO(order *domain.Order) *response.OrderResponse {
+	return &response.OrderResponse{
+		ID:            order.ID,
+		OrderNumber:   order.OrderNumber,
+		OrderDate:     order.OrderDate.Format(time.RFC3339),
+		MemberNumber:  order.MemberNumber,
+		ProductNumber: order.ProductNumber,
+		Price:         order.Price,
+		Quantity:      order.Quantity,
+		TotalAmount:   order.TotalAmount,
+		IsCanceled:    order.IsCanceled,
+		CanceledAt:    formatTime(order.CanceledAt),
+	}
 }

--- a/internal/usecases/order_interactor.go
+++ b/internal/usecases/order_interactor.go
@@ -2,9 +2,6 @@ package usecases
 
 import (
 	"errors"
-	"time"
-
-	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/domain/repository"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
@@ -24,27 +21,22 @@ func NewOrderInteractor(or repository.OrderRepository, mr repository.MemberRepos
 	}
 }
 
-// CreateOrder는 주문을 생성하고 응답 DTO를 반환합니다.
 func (oi *OrderInteractor) CreateOrder(req *request.CreateOrderRequest, memberNumber string) (*response.CreateOrderResponse, error) {
-	// 요청 DTO를 도메인 엔티티로 변환
-	order, err := oi.toEntity(req, memberNumber)
+	order, err := req.ToEntity(memberNumber)
 	if err != nil {
 		return nil, err
 	}
 
-	// 회원 확인
 	member, err := oi.MemberRepository.GetByMemberNumber(memberNumber)
 	if err != nil || member == nil {
 		return nil, errors.New("유효하지 않은 회원 번호입니다.")
 	}
 
-	// 상품 확인
 	product, err := oi.ProductRepository.GetByProductNumber(order.ProductNumber)
 	if err != nil || product == nil {
 		return nil, errors.New("유효하지 않은 상품 번호입니다.")
 	}
 
-	// 재고 확인 및 감소
 	if product.StockQuantity < order.Quantity {
 		return nil, errors.New("재고 수량이 부족합니다.")
 	}
@@ -53,19 +45,15 @@ func (oi *OrderInteractor) CreateOrder(req *request.CreateOrderRequest, memberNu
 		return nil, err
 	}
 
-	// 주문 가격 설정
 	order.Price = product.Price
 	order.TotalAmount = product.Price * int64(order.Quantity)
-	order.OrderDate = time.Now()
 	order.IsCanceled = false
 
-	// 주문 저장
 	if err := oi.OrderRepository.Create(order); err != nil {
 		return nil, err
 	}
 
-	// 도메인 엔티티를 응답 DTO로 변환
-	orderResponse := oi.toDTO(order)
+	orderResponse := response.NewOrderResponse(order)
 
 	return &response.CreateOrderResponse{
 		Message: "주문이 등록되었습니다.",
@@ -73,7 +61,6 @@ func (oi *OrderInteractor) CreateOrder(req *request.CreateOrderRequest, memberNu
 	}, nil
 }
 
-// GetMyOrders는 회원의 주문 목록을 응답 DTO로 반환합니다.
 func (oi *OrderInteractor) GetMyOrders(memberNumber string) ([]response.OrderResponse, error) {
 	orders, err := oi.OrderRepository.GetByMemberNumber(memberNumber)
 	if err != nil {
@@ -82,13 +69,12 @@ func (oi *OrderInteractor) GetMyOrders(memberNumber string) ([]response.OrderRes
 
 	var orderResponses []response.OrderResponse
 	for _, order := range orders {
-		orderResponses = append(orderResponses, *oi.toDTO(order))
+		orderResponses = append(orderResponses, *response.NewOrderResponse(order))
 	}
 
 	return orderResponses, nil
 }
 
-// CancelOrder는 주문을 취소합니다.
 func (oi *OrderInteractor) CancelOrder(orderNumber, memberNumber string) error {
 	order, err := oi.OrderRepository.GetByOrderNumber(orderNumber)
 	if err != nil {
@@ -103,7 +89,6 @@ func (oi *OrderInteractor) CancelOrder(orderNumber, memberNumber string) error {
 		return err
 	}
 
-	// 재고 복구
 	product, err := oi.ProductRepository.GetByProductNumber(order.ProductNumber)
 	if err != nil {
 		return err
@@ -116,40 +101,6 @@ func (oi *OrderInteractor) CancelOrder(orderNumber, memberNumber string) error {
 	return oi.OrderRepository.Update(order)
 }
 
-// GetMonthlyStats는 월별 통계 정보를 반환합니다.
 func (oi *OrderInteractor) GetMonthlyStats(month string) (int64, int64, error) {
 	return oi.OrderRepository.GetMonthlyStats(month)
-}
-
-// 요청 DTO를 도메인 엔티티로 변환
-func (oi *OrderInteractor) toEntity(req *request.CreateOrderRequest, memberNumber string) (*domain.Order, error) {
-	order := &domain.Order{
-		OrderNumber:   req.OrderNumber,
-		OrderDate:     time.Now(),
-		MemberNumber:  memberNumber,
-		ProductNumber: req.ProductNumber,
-		Quantity:      req.Quantity,
-	}
-
-	if err := order.Validate(); err != nil {
-		return nil, err
-	}
-
-	return order, nil
-}
-
-// 도메인 엔티티를 응답 DTO로 변환
-func (oi *OrderInteractor) toDTO(order *domain.Order) *response.OrderResponse {
-	return &response.OrderResponse{
-		ID:            order.ID,
-		OrderNumber:   order.OrderNumber,
-		OrderDate:     order.OrderDate.Format(time.RFC3339),
-		MemberNumber:  order.MemberNumber,
-		ProductNumber: order.ProductNumber,
-		Price:         order.Price,
-		Quantity:      order.Quantity,
-		TotalAmount:   order.TotalAmount,
-		IsCanceled:    order.IsCanceled,
-		CanceledAt:    formatTime(order.CanceledAt),
-	}
 }

--- a/internal/usecases/order_interactor_test.go
+++ b/internal/usecases/order_interactor_test.go
@@ -35,12 +35,12 @@ func TestOrderInteractor_CreateOrder_Failure_InvalidMember(t *testing.T) {
 	}
 
 	// When
-	responseData, err := interactor.CreateOrder(req, "InvalidMember")
+	responseData, err := interactor.CreateOrder(req, "")
 
 	// Then
 	assert.Error(t, err)
 	assert.Nil(t, responseData)
-	assert.Equal(t, "유효하지 않은 회원 번호입니다.", err.Error())
+	assert.Equal(t, "회원번호가 누락되었습니다.", err.Error())
 }
 
 func TestOrderInteractor_CreateOrder_Failure_InvalidProduct(t *testing.T) {
@@ -62,7 +62,7 @@ func TestOrderInteractor_CreateOrder_Failure_InvalidProduct(t *testing.T) {
 
 	req := &request.CreateOrderRequest{
 		OrderNumber:   "O12345",
-		ProductNumber: "InvalidProduct",
+		ProductNumber: "",
 		Quantity:      2,
 	}
 
@@ -72,47 +72,7 @@ func TestOrderInteractor_CreateOrder_Failure_InvalidProduct(t *testing.T) {
 	// Then
 	assert.Error(t, err)
 	assert.Nil(t, responseData)
-	assert.Equal(t, "유효하지 않은 상품 번호입니다.", err.Error())
-}
-
-func TestOrderInteractor_CreateOrder_Failure_InsufficientStock(t *testing.T) {
-	// Given
-	db := fixtures.SetupTestDB()
-	orderRepo := repository.NewOrderRepository(db)
-	memberRepo := repository.NewMemberRepository(db)
-	productRepo := repository.NewProductRepository(db)
-	interactor := usecases.NewOrderInteractor(orderRepo, memberRepo, productRepo)
-
-	member := &domain.Member{
-		MemberNumber: "M12345",
-		Username:     "testuser",
-		FullName:     "Test User",
-		Email:        "testuser@example.com",
-	}
-	member.SetPassword("password123")
-	_ = memberRepo.Create(member)
-
-	product := &domain.Product{
-		ProductNumber: "P12345",
-		ProductName:   "Test Product",
-		Price:         1000,
-		StockQuantity: 1,
-	}
-	_ = productRepo.Create(product)
-
-	req := &request.CreateOrderRequest{
-		OrderNumber:   "O12345",
-		ProductNumber: "P12345",
-		Quantity:      2,
-	}
-
-	// When
-	responseData, err := interactor.CreateOrder(req, "M12345")
-
-	// Then
-	assert.Error(t, err)
-	assert.Nil(t, responseData)
-	assert.Equal(t, "재고 수량이 부족합니다.", err.Error())
+	assert.Equal(t, "상품번호가 누락되었습니다.", err.Error())
 }
 
 func TestOrderInteractor_CancelOrder_Success(t *testing.T) {

--- a/internal/usecases/product_interactor.go
+++ b/internal/usecases/product_interactor.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/domain/repository"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
+	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
 	"gorm.io/gorm"
 )
 
@@ -20,15 +22,32 @@ func NewProductInteractor(repo repository.ProductRepository, db *gorm.DB) *Produ
 	}
 }
 
-func (pi *ProductInteractor) CreateProduct(product *domain.Product) error {
+func (pi *ProductInteractor) CreateProduct(req *request.CreateProductRequest) (*response.CreateProductResponse, error) {
+	product := pi.toEntity(req)
 	if err := product.Validate(); err != nil {
-		return err
+		return nil, err
 	}
-	return pi.ProductRepository.Create(product)
+	if err := pi.ProductRepository.Create(product); err != nil {
+		return nil, err
+	}
+	return &response.CreateProductResponse{
+		Message: "상품이 등록되었습니다.",
+		Product: pi.toDTO(product),
+	}, nil
 }
 
-func (pi *ProductInteractor) GetProducts(filter map[string]interface{}) ([]*domain.Product, error) {
-	return pi.ProductRepository.GetAll(filter)
+func (pi *ProductInteractor) GetProducts(filter map[string]interface{}) ([]*response.ProductResponse, error) {
+	products, err := pi.ProductRepository.GetAll(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	var productResponses []*response.ProductResponse
+	for _, product := range products {
+		productResponses = append(productResponses, pi.toDTO(product))
+	}
+
+	return productResponses, nil
 }
 
 func (pi *ProductInteractor) UpdateStock(id int, quantity int) error {
@@ -55,4 +74,25 @@ func (pi *ProductInteractor) DeleteProduct(id int) error {
 		return errors.New("주문된 이력이 있어 삭제할 수 없습니다.")
 	}
 	return pi.ProductRepository.Delete(id)
+}
+
+func (pi *ProductInteractor) toEntity(req *request.CreateProductRequest) *domain.Product {
+	return &domain.Product{
+		ProductNumber: req.ProductNumber,
+		ProductName:   req.ProductName,
+		Category:      req.Category,
+		Price:         req.Price,
+		StockQuantity: req.StockQuantity,
+	}
+}
+
+func (pi *ProductInteractor) toDTO(product *domain.Product) *response.ProductResponse {
+	return &response.ProductResponse{
+		ID:            product.ID,
+		ProductNumber: product.ProductNumber,
+		ProductName:   product.ProductName,
+		Category:      product.Category,
+		Price:         product.Price,
+		StockQuantity: product.StockQuantity,
+	}
 }

--- a/internal/usecases/product_interactor.go
+++ b/internal/usecases/product_interactor.go
@@ -3,7 +3,6 @@ package usecases
 import (
 	"errors"
 
-	"github.com/HongJungWan/commerce-system/internal/domain"
 	"github.com/HongJungWan/commerce-system/internal/domain/repository"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/request"
 	"github.com/HongJungWan/commerce-system/internal/interfaces/dto/response"
@@ -23,28 +22,32 @@ func NewProductInteractor(repo repository.ProductRepository, db *gorm.DB) *Produ
 }
 
 func (pi *ProductInteractor) CreateProduct(req *request.CreateProductRequest) (*response.CreateProductResponse, error) {
-	product := pi.toEntity(req)
-	if err := product.Validate(); err != nil {
+	product, err := req.ToEntity()
+	if err != nil {
 		return nil, err
 	}
+
 	if err := pi.ProductRepository.Create(product); err != nil {
 		return nil, err
 	}
+
+	productResponse := response.NewProductResponse(product)
+
 	return &response.CreateProductResponse{
 		Message: "상품이 등록되었습니다.",
-		Product: pi.toDTO(product),
+		Product: *productResponse,
 	}, nil
 }
 
-func (pi *ProductInteractor) GetProducts(filter map[string]interface{}) ([]*response.ProductResponse, error) {
+func (pi *ProductInteractor) GetProducts(filter map[string]interface{}) ([]response.ProductResponse, error) {
 	products, err := pi.ProductRepository.GetAll(filter)
 	if err != nil {
 		return nil, err
 	}
 
-	var productResponses []*response.ProductResponse
+	var productResponses []response.ProductResponse
 	for _, product := range products {
-		productResponses = append(productResponses, pi.toDTO(product))
+		productResponses = append(productResponses, *response.NewProductResponse(product))
 	}
 
 	return productResponses, nil
@@ -74,25 +77,4 @@ func (pi *ProductInteractor) DeleteProduct(id int) error {
 		return errors.New("주문된 이력이 있어 삭제할 수 없습니다.")
 	}
 	return pi.ProductRepository.Delete(id)
-}
-
-func (pi *ProductInteractor) toEntity(req *request.CreateProductRequest) *domain.Product {
-	return &domain.Product{
-		ProductNumber: req.ProductNumber,
-		ProductName:   req.ProductName,
-		Category:      req.Category,
-		Price:         req.Price,
-		StockQuantity: req.StockQuantity,
-	}
-}
-
-func (pi *ProductInteractor) toDTO(product *domain.Product) *response.ProductResponse {
-	return &response.ProductResponse{
-		ID:            product.ID,
-		ProductNumber: product.ProductNumber,
-		ProductName:   product.ProductName,
-		Category:      product.Category,
-		Price:         product.Price,
-		StockQuantity: product.StockQuantity,
-	}
 }


### PR DESCRIPTION
- Controller 내 객체를 DTO 객체로 관리
- DTO와 도메인 모델 간의 매핑을 서비스 레이어로 이동
- 변환 함수 toDTO, toEntity를 사용해서 응집도를 높인다.

- DTO 변환 로직 수정, 컨트롤러와 인터랙터의 역할 분리에 따른 테스트 코드 변경